### PR TITLE
failed test fix

### DIFF
--- a/Changes
+++ b/Changes
@@ -3,3 +3,9 @@ Revision history for Time-Duration-Concise-Localize
 0.01    18/06/2014
         First version, released on cpan.
 
+0.02    19/06/2014
+        Fix cpan failed test reports
+
+0.03    26/06/2014
+        Fix makefile, we need Time::Second 1.27 version
+

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -18,7 +18,7 @@ WriteMakefile(
         'Test::More'         => 0,
         'Test::FailWarnings' => 0,
         'Test::Exception'    => 0,
-        'Time::Seconds'      => 0,
+        'Time::Seconds'      => 1.27,
         'Moo'                => 0,
         'Carp'               => 0,
         'Module::Runtime'    => 0,

--- a/lib/Time/Duration/Concise/Localize.pm
+++ b/lib/Time/Duration/Concise/Localize.pm
@@ -9,7 +9,7 @@ extends 'Time::Duration::Concise';
 
 use Module::Runtime qw(require_module);
 
-our $VERSION = '0.02';
+our $VERSION = '0.03';
 
 =head1 NAME
 
@@ -21,7 +21,7 @@ Time::Duration::Concise is an approach to localize concise time duration string 
 
 =head1 VERSION
 
-Version 0.02
+Version 0.03
 
 =head1 SYNOPSIS
 


### PR DESCRIPTION
Failed test fixes for CPAN, specified version number for Time::Seconds module, cause of fail test.
