### PR TITLE
Various improvements

### DIFF
--- a/Changes
+++ b/Changes
@@ -9,3 +9,7 @@ Revision history for Time-Duration-Concise-Localize
 0.03    26/06/2014
         Fix makefile, we need Time::Second 1.27 version
 
+0.04    28/06/2014
+        Various improvements, now if time concise format is just number, we assume it is seconds
+        as_concise_string method will rebuild time concise format
+        normalized_code code is part of consie module, instead of Localize. That's the better place.

--- a/lib/Time/Duration/Concise/Localize.pm
+++ b/lib/Time/Duration/Concise/Localize.pm
@@ -9,7 +9,7 @@ extends 'Time::Duration::Concise';
 
 use Module::Runtime qw(require_module);
 
-our $VERSION = '0.03';
+our $VERSION = '0.04';
 
 =head1 NAME
 
@@ -21,7 +21,7 @@ Time::Duration::Concise is an approach to localize concise time duration string 
 
 =head1 VERSION
 
-Version 0.03
+Version 0.04
 
 =head1 SYNOPSIS
 
@@ -106,28 +106,6 @@ sub as_string {
         );
     }
     return join(', ', @duration_translated);
-}
-
-=head2 entry_code
-
-The largest division of this [Duration]
-
-=cut
-
-sub normalized_code {
-    my ( $self ) = @_;
-
-    my %length_to_period = %Time::Duration::Concise::LENGTH_TO_PERIOD;
-    my @keys = sort { $b <=> $a } keys %length_to_period;
-
-    my $entry_code = '0s';
-    foreach my $period_length ( @keys ) {
-        if ( not $self->seconds % $period_length ) {
-            my $period_size = $self->seconds / $period_length;
-            $entry_code = $period_size . substr($length_to_period{$period_length}, 0, 1);
-        }
-    }
-    return $entry_code;
 }
 
 =head1 AUTHOR

--- a/t/02-concise_localize.t
+++ b/t/02-concise_localize.t
@@ -10,7 +10,7 @@ use Time::Duration::Concise::Localize;
 
 use lib 't';
 
-plan tests => 15;
+plan tests => 16;
 
 my $duration = Time::Duration::Concise::Localize->new(
     interval => '1d1.5h',
@@ -28,6 +28,7 @@ is ( $duration->as_string, '1 hari, 1 jam, 30 minit', 'As string');
 is ( $duration->as_string(1), '1 hari', 'As string precision 1');
 is ( $duration->as_string(2), '1 hari, 1 jam', 'As string precision 2');
 is ( $duration->as_string(3), '1 hari, 1 jam, 30 minit', 'As string precision 3');
+is ( $duration->as_concise_string, '1d1h30m', 'Concise format');
 is ( scalar @{$duration->duration_array(3)}, '3', 'Duration array precision 3');
 is ( scalar @{$duration->duration_array(1)}, '1', 'Duration array precision 1');
 is ( $duration->minimum_number_of('seconds'), 91800, 'Minimum number of seconds');


### PR DESCRIPTION
Various improvements, now if time concise format is just number, we assume it is seconds
as_concise_string method will rebuild time concise format
normalized_code code is part of concise module, instead of Localize. That's the better place.
