### PR TITLE
Remove redundant README generation

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -12,7 +12,6 @@ except = t/rc/\.perl*rc$
 [ManifestSkip]
 [MetaYAML]
 [License]
-[Readme]
 [MakeMaker]
 eumm_version = 6.48
 prereq_fatal = 1

--- a/t/boilerplate.t
+++ b/t/boilerplate.t
@@ -39,7 +39,7 @@ sub module_boilerplate_ok {
 }
 
 
-  not_in_file_ok(README =>
+  not_in_file_ok('README.md' =>
     "The README is used..."       => qr/The README is used/,
     "'version information here'"  => qr/to provide version information/,
   );


### PR DESCRIPTION
We already have a README.md so this is unnecessary, and the test for
this breaks the ability to install this dist directly from git.